### PR TITLE
Introduced Endpoint object (with some sample components to show usage)

### DIFF
--- a/visiui/src/app/globals.css
+++ b/visiui/src/app/globals.css
@@ -2,3 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
+.visiui-label {
+    color: white;
+}
+
+.visiui-textfield {
+    border: none;
+    outline: none;
+    border-bottom: 1px solid rgb(0, 66, 87);
+    background-color: transparent;
+    color: white;
+}
+
+.visiui-textfield:focus {
+    border-bottom: 1px solid rgb(95, 192, 221);
+}

--- a/visiui/src/app/page.tsx
+++ b/visiui/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import Endpoint from "@/data-components/Endpoint";
 import TextField from "@/ui-components/TextField";
 import Label from "@/ui-components/Label";

--- a/visiui/src/app/page.tsx
+++ b/visiui/src/app/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
 import Endpoint from "@/data-components/Endpoint";
 import TextField from "@/ui-components/TextField";
 import Label from "@/ui-components/Label";

--- a/visiui/src/app/page.tsx
+++ b/visiui/src/app/page.tsx
@@ -1,9 +1,17 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useState } from "react";
+import Endpoint from "@/data-components/Endpoint";
+import TextField from "@/ui-components/TextField";
+import Label from "@/ui-components/Label";
+
+const sampleValue = new Endpoint<string>({ value: "Edit me!" });
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-slate-950">
-      
+      <Label value={sampleValue} />
+      <TextField value={sampleValue} />
     </main>
   );
 }

--- a/visiui/src/data-components/Endpoint.ts
+++ b/visiui/src/data-components/Endpoint.ts
@@ -2,7 +2,7 @@ type Destructor = () => any;
 type Handler<T> = (value: T) => Destructor | undefined | void;
 type Handle<T> = {
     handler: Handler<T>
-    dispose?: Destructor | undefined | void
+    dispose: Destructor | undefined | void
 }
 
 class Binding<T> {

--- a/visiui/src/data-components/Endpoint.ts
+++ b/visiui/src/data-components/Endpoint.ts
@@ -1,0 +1,91 @@
+type Destructor = () => any;
+type Handler<T> = (value: T) => Destructor | undefined | void;
+type Handle<T> = {
+    handler: Handler<T>
+    dispose?: Destructor | undefined | void
+}
+
+class Binding<T> {
+    endpoint: Endpoint<T>
+    handles: Array<Handle<T>>
+
+    constructor(endpoint: Endpoint<T>) {
+        this.endpoint = endpoint;
+        this.handles = [];
+        this.dispose = this.dispose.bind(this);
+        this.onSet = this.onSet.bind(this);
+        this.apply = this.apply.bind(this);
+        this.set = this.set.bind(this);
+    }
+
+    dispose() {
+        for (let handle of this.handles) if (handle.dispose) handle.dispose();
+        this.endpoint.bindings.splice(this.endpoint.bindings.indexOf(this), 1);
+    }
+
+    onSet(handler: Handler<T>): Destructor {
+        let handle: Handle<T> = { handler };
+        this.handles.push(handle);
+        if (this.endpoint.initialized && this.endpoint.value) handle.dispose = handler(this.endpoint.value);
+        return () => {
+            if (handle.dispose) handle.dispose();
+            this.handles.splice(this.handles.indexOf(handle), 1);
+        }
+    }
+
+    apply(value: T) {
+        for (let handle of this.handles) {
+            if (handle.dispose) handle.dispose();
+            handle.dispose = handle.handler(value);
+        }
+    }
+
+    set(value: T) {
+        this.endpoint.set(value, this);
+    }
+}
+
+export default class Endpoint<T> {
+    bindings: Array<Binding<T>>
+    value: T | undefined
+    initialized: boolean
+
+    constructor(props: { value?: T }) {
+        this.bindings = [];
+        this.value = props.value;
+        this.initialized = props.value != undefined;
+        this.dispose = this.dispose.bind(this);
+        this.bind = this.bind.bind(this);
+        this.set = this.set.bind(this);
+        this.onSet = this.onSet.bind(this);
+    }
+
+    dispose() {
+        for (let binding of this.bindings) binding.dispose();
+    }
+
+    bind(): Binding<T> {
+        let binding = new Binding(this);
+        this.bindings.push(binding);
+        return binding;
+    }
+
+    set(value: T, ignore: Binding<T>) {
+        if (value == this.value) return;
+        this.value = value;
+        this.initialized = true;
+        for (let binding of this.bindings) {
+            if (binding == ignore) continue;
+            binding.apply(value);
+        }
+    }
+
+    onSet(handler: Handler<T>): Destructor {
+        let binding = this.bind();
+        let dispose = binding.onSet(handler);
+        return () => {
+            dispose();
+            binding.dispose();
+        }
+    }
+}

--- a/visiui/src/ui-components/Label.tsx
+++ b/visiui/src/ui-components/Label.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import Endpoint from "@/data-components/Endpoint";
+import { useEffect, useState } from "react";
+
+export default function Label(props: { value: Endpoint<string> }) {
+    let [text, setText] = useState("");
+    useEffect(() => props.value.onSet(setText));
+    return <div className='visiui-label'>{text}</div>
+}

--- a/visiui/src/ui-components/Label.tsx
+++ b/visiui/src/ui-components/Label.tsx
@@ -3,7 +3,7 @@
 import Endpoint from "@/data-components/Endpoint";
 import { useEffect, useState } from "react";
 
-export default function Label(props: { value: Endpoint<string> }) {
+export default function Label(props: { readonly value: Endpoint<string> }) {
     let [text, setText] = useState("");
     useEffect(() => props.value.onSet(setText));
     return <div className='visiui-label'>{text}</div>

--- a/visiui/src/ui-components/TextField.tsx
+++ b/visiui/src/ui-components/TextField.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Endpoint from '@/data-components/Endpoint';
+import React, { useEffect, useMemo, useState } from 'react'
+
+export default function TextField(props: { value: Endpoint<string> }) {
+  const binding = useMemo(props.value.bind, []);
+  let [text, setText] = useState("");
+  useEffect(() => binding.onSet(setText), []);
+
+  return (
+    <input
+      className='visiui-textfield'
+      value={text}
+      onChange={e => setText(e.target.value)}
+      onKeyDown={e => e.key == 'Enter' && binding.set(text)}
+      onBlur={() => binding.set(text)}
+    />
+  )
+}

--- a/visiui/src/ui-components/TextField.tsx
+++ b/visiui/src/ui-components/TextField.tsx
@@ -3,7 +3,7 @@
 import Endpoint from '@/data-components/Endpoint';
 import React, { useEffect, useMemo, useState } from 'react'
 
-export default function TextField(props: { value: Endpoint<string> }) {
+export default function TextField(props: { readonly value: Endpoint<string> }) {
   const binding = useMemo(props.value.bind, []);
   let [text, setText] = useState("");
   useEffect(() => binding.onSet(setText), []);


### PR DESCRIPTION
The `Endpoint` object allows you to create a publish/subscriber model, where UI components can selectively bind to data elements of interest, with the intent of only re-rendering a component when needed.
By interfacing with a per-client `Binding` object, components can propagate changes upstream without receiving a reflection of the same update to their own binding.